### PR TITLE
Additional parameters to control segmentation inference.

### DIFF
--- a/ultralytics/cfg/__init__.py
+++ b/ultralytics/cfg/__init__.py
@@ -94,7 +94,7 @@ CLI_HELP_MSG = f"""
     """
 
 # Define keys for arg type checks
-CFG_FLOAT_KEYS = {"warmup_epochs", "box", "cls", "dfl", "degrees", "shear", "time", "workspace"}
+CFG_FLOAT_KEYS = {"warmup_epochs", "box", "cls", "dfl", "degrees", "shear", "time", "workspace", "box_margin_factor"}
 CFG_FRACTION_KEYS = {
     "dropout",
     "iou",
@@ -134,6 +134,7 @@ CFG_INT_KEYS = {
     "line_width",
     "nbs",
     "save_period",
+    "box_max_margin",
 }
 CFG_BOOL_KEYS = {
     "save",

--- a/ultralytics/cfg/default.yaml
+++ b/ultralytics/cfg/default.yaml
@@ -62,6 +62,8 @@ augment: False # (bool) apply image augmentation to prediction sources
 agnostic_nms: False # (bool) class-agnostic NMS
 classes: # (int | list[int], optional) filter results by class, i.e. classes=0, or classes=[0,2,3]
 retina_masks: False # (bool) use high-resolution segmentation masks
+box_margin_factor: 2.0 # (float) bounding box margin
+box_max_margin: 20 # (int) bounding box max margin
 embed: # (list[int], optional) return feature vectors/embeddings from given layers
 
 # Visualize settings ---------------------------------------------------------------------------------------------------

--- a/ultralytics/models/yolo/segment/predict.py
+++ b/ultralytics/models/yolo/segment/predict.py
@@ -49,9 +49,24 @@ class SegmentationPredictor(DetectionPredictor):
                 masks = None
             elif self.args.retina_masks:
                 pred[:, :4] = ops.scale_boxes(img.shape[2:], pred[:, :4], orig_img.shape)
-                masks = ops.process_mask_native(proto[i], pred[:, 6:], pred[:, :4], orig_img.shape[:2])  # HWC
+                masks = ops.process_mask_native(
+                    proto[i],
+                    pred[:, 6:],
+                    pred[:, :4],
+                    orig_img.shape[:2],
+                    box_margin_factor=self.args.box_margin_factor,
+                    box_max_margin=self.args.box_max_margin
+                )  # HWC
             else:
-                masks = ops.process_mask(proto[i], pred[:, 6:], pred[:, :4], img.shape[2:], upsample=True)  # HWC
+                masks = ops.process_mask(
+                    proto[i],
+                    pred[:, 6:],
+                    pred[:, :4],
+                    img.shape[2:],
+                    upsample=True,
+                    box_margin_factor=self.args.box_margin_factor,
+                    box_max_margin=self.args.box_max_margin
+                )  # HWC
                 pred[:, :4] = ops.scale_boxes(img.shape[2:], pred[:, :4], orig_img.shape)
             results.append(Results(orig_img, path=img_path, names=self.model.names, boxes=pred[:, :6], masks=masks))
         return results


### PR DESCRIPTION
* Allow masks to spill over detection boxes boundaries
* Always return mask logits

![image](https://github.com/user-attachments/assets/96d2317e-5500-4afa-af0b-7d188b5fe2a3)
